### PR TITLE
Fix default OpenAI model typo

### DIFF
--- a/background.js
+++ b/background.js
@@ -614,7 +614,7 @@ async function sendToOpenAI() {
   const { openai_api_key, openai_model, system_prompt } =
     await chrome.storage.local.get({
       openai_api_key: "",
-      openai_model: "gpt-4o-min",
+      openai_model: "gpt-4o-mini",
       system_prompt: "",
     });
 

--- a/test/defaultModel.test.js
+++ b/test/defaultModel.test.js
@@ -1,0 +1,10 @@
+import fs from 'fs/promises';
+import assert from 'node:assert';
+import test from 'node:test';
+
+const filePath = new URL('../background.js', import.meta.url);
+
+ test('background.js uses correct OpenAI model default', async () => {
+  const content = await fs.readFile(filePath, 'utf8');
+  assert.ok(content.includes('openai_model: "gpt-4o-mini"'));
+ });


### PR DESCRIPTION
## Summary
- fix OpenAI default model string
- add minimal Node test to assert the default model value

## Testing
- `node --test test/defaultModel.test.js`
- `node --test --experimental-test-coverage test/defaultModel.test.js`
- `bundle exec rubocop` *(fails: Could not locate Gemfile)*
- `bundle exec brakeman` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6849aed0cb808323855db21d8ffe298d