### PR TITLE
Add options defaults test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: node --test --experimental-test-coverage

--- a/test/optionsDefaults.test.js
+++ b/test/optionsDefaults.test.js
@@ -1,0 +1,37 @@
+import fs from 'fs/promises';
+import assert from 'node:assert';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const filePath = new URL('../options.js', import.meta.url);
+
+test('options.js exposes expected DEFAULT_OPTIONS values', async () => {
+  let content = await fs.readFile(filePath, 'utf8');
+  // expose the constant on the global object so we can inspect it
+  content = content.replace(
+    'const DEFAULT_OPTIONS = {',
+    'globalThis.DEFAULT_OPTIONS = {'
+  );
+
+  const context = {
+    chrome: { storage: { local: { get: async () => ({}), set: () => {} } } },
+    document: {
+      getElementById: () => ({
+        addEventListener() {},
+        value: '',
+        checked: false,
+        style: {},
+      }),
+      addEventListener() {},
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(content, context);
+
+  const defaults = context.DEFAULT_OPTIONS;
+
+  assert.strictEqual(defaults.provider, 'openai');
+  assert.strictEqual(defaults.openai_model, 'gpt-4o-mini');
+  assert.strictEqual(defaults.gemini_model, 'gemini-2.0-flash-exp');
+  assert.strictEqual(defaults.ollama_model, 'llama3.2-vision');
+});

--- a/test/optionsHtml.test.js
+++ b/test/optionsHtml.test.js
@@ -1,0 +1,12 @@
+import fs from 'fs/promises';
+import assert from 'node:assert';
+import test from 'node:test';
+
+const htmlPath = new URL('../options.html', import.meta.url);
+
+test('options.html loads options.js and has key elements', async () => {
+  const html = await fs.readFile(htmlPath, 'utf8');
+  assert.ok(html.includes('script src="options.js"'));
+  assert.ok(html.includes('id="provider"'));
+  assert.ok(html.includes('id="openaiModel"'));
+});


### PR DESCRIPTION
## Summary
- add a new test ensuring `options.js` defaults match expected provider and models
- verify key UI fields in `options.html`
- add CI workflow to run tests using GitHub Actions

## Testing
- `node --test --experimental-test-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6849b02d85e88323bd9b1e8217c8a19e